### PR TITLE
Fixes "Unresolvable cycle detected" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "main": "lib/oauth2server.js",
   "dependencies": {
-    "node-oauth2-server-restify": "git+https://github.com/marsanla/node-oauth2-server-restify.git",
     "basic-auth": "~0.0.1",
     "node-restify-errors": "~0.1.0"
   },


### PR DESCRIPTION
Just fixes this error when trying to install:

``` js
$ npm i oauth2-server-restify --save
npm WARN package.json papi-rest@0.0.1 No license field.
npm ERR! Darwin 14.0.0
npm ERR! argv "node" "/usr/local/bin/npm" "i" "oauth2-server-restify" "--save"
npm ERR! node v0.12.5
npm ERR! npm  v2.11.3
npm ERR! code ECYCLE

npm ERR! cycle Unresolvable cycle detected
npm ERR! cycle While installing: oauth2-server-restify@2.3.2
npm ERR! cycle Found a pathological dependency case that npm cannot solve.
npm ERR! cycle Please report this to the package author.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/marcogodinez/dev/sprint2/papi-rest/npm-debug.log
```
